### PR TITLE
Fixes maxlength validation bugs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,5 @@ Josh Kearney <josh@jk0.org>
 Michael Barton <mike@weirdlooking.com>
 Rainer Toebbicke <Rainer.Toebbicke@cern.ch>
 Scott Simpson <sasimpson@gmail.com>
+Tom Fifield <fifieldt@unimelb.edu.au>
 Victor Rodionov <vito.ordaz@gmail.com>


### PR DESCRIPTION
The following S3 tests were failing:
s3tests.functional.test_s3.test_bucket_list_maxkeys_invalid
s3tests.functional.test_s3.test_bucket_list_maxkeys_unreadable
s3tests.functional.test_s3.test_bucket_list_maxkeys_zero

These two simple changes add some validation for the first two
and fixes the return of is_truncated for the maxkeys=0 case.
Tests now pass.
