### PR TITLE
Stubbed out versioning command 

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -270,7 +270,7 @@ def canonical_string(req):
         path, args = path.split('?', 1)
         for key in urlparse.parse_qs(args, keep_blank_values=True):
             if key in ('acl', 'logging', 'torrent', 'location',
-                       'requestPayment'):
+                       'requestPayment', 'versioning'):
                 return "%s%s?%s" % (buf, path, key)
     return buf + path
 
@@ -430,6 +430,12 @@ class BucketController(WSGIContext):
 
         if 'acl' in args:
             return get_acl(self.account_name, headers)
+
+        if 'versioning' in args:
+            # Just report there is no versioning configured here.
+            body = ('<VersioningConfiguration '
+                'xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>')
+            return Response(body=body, content_type="text/plain")
 
         if status != HTTP_OK:
             if status == HTTP_UNAUTHORIZED:

--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -408,6 +408,16 @@ class TestSwift3(unittest.TestCase):
         resp = local_app(req.environ, local_app.app.do_start_response)
         self._check_acl('test:tester', resp)
 
+    def test_bucket_versioning_GET(self):
+        local_app = swift3.filter_factory({})(FakeAppBucket())
+        bucket_name = 'junk'
+        req = Request.blank('/%s?versioning' % bucket_name,
+                            environ={'REQUEST_METHOD': 'GET'},
+                            headers={'Authorization': 'AWS test:tester:hmac'})
+        resp = local_app(req.environ, local_app.app.do_start_response)
+        dom = xml.dom.minidom.parseString("".join(resp))
+        self.assertEquals(dom.firstChild.nodeName, 'VersioningConfiguration')
+
     def _test_object_GETorHEAD(self, method):
         local_app = swift3.filter_factory({})(FakeAppObject())
         req = Request.blank('/bucket/object',


### PR DESCRIPTION
This is necessary for CyberDuck, which issues the versioning command and errors
out if that doesn't work. This implementation simply returns that versioning
hasn't been configured.

See: http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketGETversioningStatus.html
