### PR TITLE
fix signature bug to use RAW_PATH_INFO

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -266,7 +266,10 @@ def canonical_string(req):
     for k in sorted(key.lower() for key in amz_headers):
         buf += "%s:%s\n" % (k, amz_headers[k])
 
-    path = req.path
+    # RAW_PATH_INFO is enabled in later version than eventlet 0.9.17.
+    # When using older version, swift3 uses req.path of swob instead
+    # of it.
+    path = req.environ.get('RAW_PATH_INFO', req.path)
     if req.query_string:
         path += '?' + req.query_string
     if '?' in path:


### PR DESCRIPTION
This fixes signature creation to use RAW_PATH_INFO.

Swift3 could not create correct signature in case of
using escaped character(e.g. %2F, %2D) in PATH_INFO,
because env['PATH_INFO'] was decoded(unescaped) by
eventlet.wsgi before a request arrived at swift3.
It caused signature mismatch and authentication failure.

This change enables swift3 to create signature from
RAW_PATH_INFO and fixes that bug.

Note: This patch works well only in later version than
      eventlet 0.9.17, because older version does not
      have RAW_PATH_INFO variable.
      When using older version, swift3 works in the same
      way as ever(use req.path of swob).

Signed-off-by: Kota Tsuyuzaki tsuyuzaki.kota@lab.ntt.co.jp
