### PR TITLE
Content-Range uses space after bytes 

### DIFF
--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -476,7 +476,7 @@ class TestSwift3(unittest.TestCase):
         headers = dict((k.lower(), v) for k, v in
             local_app.app.response_args[1])
         self.assertTrue('content-range' in  headers)
-        self.assertTrue(headers['content-range'].startswith('bytes=0-3'))
+        self.assertTrue(headers['content-range'].startswith('bytes 0-3'))
 
     def test_object_PUT_error(self):
         code = self._test_method_error(FakeAppObject, 'PUT',


### PR DESCRIPTION
Our test expected "Content-Range: bytes=0-N", but this is incorrect.
The RFC-2616 14.16 clearly says:
  bytes-unit SP byte-range-resp-spec "/" ( instance-length | "*" )

This is different from Ranges where bytes=0-N is specified.
The wonders of Web standards!

If a version of swob sent the equal sign previously, it was wrong,
but now corrected.

With this in place, unit tests pass.
