### PR TITLE
Undo part of patch by Willys

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -586,10 +586,11 @@ class BucketController(WSGIContext):
         self._app_call(env)
         status = self._get_status_int()
 
-        if status != HTTP_CREATED and status != HTTP_NO_CONTENT and \
-           status != HTTP_ACCEPTED:
+        if status != HTTP_CREATED and status != HTTP_NO_CONTENT:
             if status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
                 return get_err_response('AccessDenied')
+            elif status == HTTP_ACCEPTED:
+                return get_err_response('BucketAlreadyExists')
             else:
                 return get_err_response('InvalidURI')
 


### PR DESCRIPTION
A regression in tests was introduced by commit
12163092ab793c6d0a1b2883f5e1858b97991e22, intended to
fix issue #49.

Willys' code actually seems to make sense, but I chose
to undo it because
- It appears to be extraneous to the issue #49
- It does not fix the tests or remove the now-unused constant

Someone should re-fix it properly. But for now I prefer tests
continue to pass.
