### PR TITLE
Add a error of EntityTooLarge

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -70,7 +70,8 @@ from swift.common.swob import Request, Response
 from swift.common.http import HTTP_OK, HTTP_CREATED, HTTP_ACCEPTED, \
     HTTP_NO_CONTENT, HTTP_BAD_REQUEST, HTTP_UNAUTHORIZED, HTTP_FORBIDDEN, \
     HTTP_NOT_FOUND, HTTP_CONFLICT, HTTP_UNPROCESSABLE_ENTITY, is_success, \
-    HTTP_NOT_IMPLEMENTED, HTTP_LENGTH_REQUIRED, HTTP_SERVICE_UNAVAILABLE
+    HTTP_NOT_IMPLEMENTED, HTTP_LENGTH_REQUIRED, HTTP_SERVICE_UNAVAILABLE, \
+    HTTP_REQUEST_ENTITY_TOO_LARGE
 
 
 MAX_BUCKET_LISTING = 1000
@@ -108,6 +109,9 @@ def get_err_response(code):
         (HTTP_BAD_REQUEST, 'The Content-MD5 you specified was invalid'),
         'BadDigest':
         (HTTP_BAD_REQUEST, 'The Content-Length you specified was invalid'),
+        'EntityTooLarge':
+        (HTTP_BAD_REQUEST, 'Your proposed upload exceeds the maximum '
+            'allowed object size.'),
         'NoSuchBucket':
         (HTTP_NOT_FOUND, 'The specified bucket does not exist'),
         'SignatureDoesNotMatch':
@@ -798,6 +802,8 @@ class ObjectController(WSGIContext):
                 return get_err_response('NoSuchBucket')
             elif status == HTTP_UNPROCESSABLE_ENTITY:
                 return get_err_response('InvalidDigest')
+            elif status == HTTP_REQUEST_ENTITY_TOO_LARGE:
+                return get_err_response('EntityTooLarge')
             else:
                 return get_err_response('InvalidURI')
 

--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -23,7 +23,7 @@ import simplejson
 
 from swift.common.swob import Request, Response, HTTPUnauthorized, \
     HTTPCreated,HTTPNoContent, HTTPAccepted, HTTPBadRequest, HTTPNotFound, \
-    HTTPConflict, HTTPForbidden
+    HTTPConflict, HTTPForbidden, HTTPRequestEntityTooLarge
 
 from swift3 import middleware as swift3
 
@@ -167,6 +167,9 @@ class FakeAppObject(FakeApp):
                 start_response(HTTPForbidden(request=req).status, [])
             elif self.status == 404:
                 start_response(HTTPNotFound(request=req).status, [])
+            elif self.status == 413:
+                start_response(HTTPRequestEntityTooLarge(request=req).status,
+                               [])
             else:
                 start_response(HTTPBadRequest(request=req).status, [])
         elif env['REQUEST_METHOD'] == 'DELETE':
@@ -513,6 +516,9 @@ class TestSwift3(unittest.TestCase):
         code = self._test_method_error(FakeAppObject, 'PUT',
                                        '/bucket/object', 404)
         self.assertEquals(code, 'NoSuchBucket')
+        code = self._test_method_error(FakeAppObject, 'PUT',
+                                       '/bucket/object', 413)
+        self.assertEquals(code, 'EntityTooLarge')
         code = self._test_method_error(FakeAppObject, 'PUT',
                                        '/bucket/object', 0)
         self.assertEquals(code, 'InvalidURI')


### PR DESCRIPTION
This fix makes to return 'EntityTooLarge' response,
when the object which user try to upload exceeds the maximum
allowed object size of swift.

Signed-off-by: Kota Tsuyuzaki tsuyuzaki.kota@lab.ntt.co.jp
