### PR TITLE
prevent double-quoting object name

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -852,7 +852,7 @@ class Swift3Middleware(object):
 
     def get_controller(self, env, path):
         container, obj = split_path(path, 0, 2, True)
-        d = dict(container_name=container, object_name=obj)
+        d = dict(container_name=container, object_name=unquote(obj))
 
         if 'QUERY_STRING' in env:
             args = dict(urlparse.parse_qsl(env['QUERY_STRING'], 1))


### PR DESCRIPTION
If we send request to object, that containt quoted symbols, than it will be quoted once again.

Such as if we send request `...New%20Folder`, than it stores as `...New%2520Folder`, not `...New%20Folder` as should be.

This pull requests fix it.
