### PR TITLE
Fix listing bucket when key contains special URL charcters

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -534,7 +534,7 @@ class BucketController(WSGIContext):
                         'ied><ETag>%s</ETag><Size>%s</Size><StorageClass>STA'
                         'NDARD</StorageClass><Owner><ID>%s</ID><DisplayName>'
                         '%s</DisplayName></Owner></Contents>' %
-                        (xml_escape(unquote(i['name'])), i['last_modified'],
+                        (xml_escape(i['name']), i['last_modified'],
                          i['hash'],
                          i['bytes'], self.account_name, self.account_name)
                          for i in objects[:max_keys] if 'subdir' not in i]),

--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -74,7 +74,9 @@ class FakeAppBucket(FakeApp):
         self.status = status
         self.objects = (('rose', '2011-01-05T02:19:14.275290', 0, 303),
                         ('viola', '2011-01-05T02:19:14.275290', 0, 3909),
-                        ('lily', '2011-01-05T02:19:14.275290', 0, 3909))
+                        ('lily', '2011-01-05T02:19:14.275290', 0, 3909),
+                        ('with space', '2011-01-05T02:19:14.275290', 0, 3909),
+                        ('with%20space', '2011-01-05T02:19:14.275290', 0, 3909))
 
     def __call__(self, env, start_response):
         if env['REQUEST_METHOD'] == 'GET':
@@ -305,7 +307,7 @@ class TestSwift3(unittest.TestCase):
 
         req = Request.blank('/%s' % bucket_name,
                 environ={'REQUEST_METHOD': 'GET',
-                         'QUERY_STRING': 'max-keys=3'},
+                         'QUERY_STRING': 'max-keys=5'},
                 headers={'Authorization': 'AWS test:tester:hmac'})
         resp = local_app(req.environ, local_app.app.do_start_response)
         dom = xml.dom.minidom.parseString("".join(resp))
@@ -314,7 +316,7 @@ class TestSwift3(unittest.TestCase):
 
         req = Request.blank('/%s' % bucket_name,
                 environ={'REQUEST_METHOD': 'GET',
-                         'QUERY_STRING': 'max-keys=2'},
+                         'QUERY_STRING': 'max-keys=4'},
                 headers={'Authorization': 'AWS test:tester:hmac'})
         resp = local_app(req.environ, local_app.app.do_start_response)
         dom = xml.dom.minidom.parseString("".join(resp))


### PR DESCRIPTION
When a key contains a special URL char (ex: %20) the key
name is unquote when listed in a bucket.
This result is having, for example "my name" and "my%20name"
be listed the same way although they are two different objects.

This patch remove unquote call on the object name, to stick with AWS S3
behavior and add/update unittest for this case. 
