### PR TITLE
Fix swift3 behavior with set_acl to existing container

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -563,6 +563,9 @@ class BucketController(WSGIContext):
             # for ACLs, whereas S3 uses PUT.
             del env['HTTP_X_AMZ_ACL']
             if 'QUERY_STRING' in env:
+                args = dict(urlparse.parse_qsl(env['QUERY_STRING'], 1))
+                if 'acl' in args:
+                    env['REQUEST_METHOD'] = 'POST'
                 del env['QUERY_STRING']
 
             translated_acl = swift_acl_translate(amz_acl)

--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -18,12 +18,13 @@ from datetime import datetime
 import cgi
 import hashlib
 import base64
+import urllib
 
 import xml.dom.minidom
 import simplejson
 
 from swift.common.swob import Request, Response, HTTPUnauthorized, \
-    HTTPCreated,HTTPNoContent, HTTPAccepted, HTTPBadRequest, HTTPNotFound, \
+    HTTPCreated, HTTPNoContent, HTTPAccepted, HTTPBadRequest, HTTPNotFound, \
     HTTPConflict, HTTPForbidden, HTTPRequestEntityTooLarge
 
 from swift3 import middleware as swift3
@@ -200,7 +201,7 @@ class TestSwift3(unittest.TestCase):
         resp = self.app(req.environ, start_response)
         self.assertEquals(resp, 'FAKE APP')
 
-    def test_bad_format_authorization(self):
+    def test_bad_format_authorization_no_info(self):
         req = Request.blank('/something',
                             headers={'Authorization': 'hoge'})
         resp = self.app(req.environ, start_response)
@@ -208,6 +209,15 @@ class TestSwift3(unittest.TestCase):
         self.assertEquals(dom.firstChild.nodeName, 'Error')
         code = dom.getElementsByTagName('Code')[0].childNodes[0].nodeValue
         self.assertEquals(code, 'AccessDenied')
+
+    def test_bad_format_authorization_with_bad_info(self):
+        req = Request.blank('/something',
+                            headers={'Authorization': 'AWS poge'})
+        resp = self.app(req.environ, start_response)
+        dom = xml.dom.minidom.parseString("".join(resp))
+        self.assertEquals(dom.firstChild.nodeName, 'Error')
+        code = dom.getElementsByTagName('Code')[0].childNodes[0].nodeValue
+        self.assertEquals(code, 'InvalidArgument')
 
     def test_bad_method(self):
         req = Request.blank('/',
@@ -424,7 +434,9 @@ class TestSwift3(unittest.TestCase):
         self.assertEquals(local_app.app.response_args[0].split()[0], '204')
 
     def _check_acl(self, owner, resp):
-        dom = xml.dom.minidom.parseString("".join(resp))
+        xml_string = ''.join(resp)
+        import sys; print >>sys.stderr, 'xml_string: %s' % xml_string
+        dom = xml.dom.minidom.parseString(xml_string)
         self.assertEquals(dom.firstChild.nodeName, 'AccessControlPolicy')
         name = dom.getElementsByTagName('Permission')[0].childNodes[0].nodeValue
         self.assertEquals(name, 'FULL_CONTROL')
@@ -472,6 +484,8 @@ class TestSwift3(unittest.TestCase):
 
         if method == 'GET':
             self.assertEquals(''.join(resp), local_app.app.object_body)
+        else:
+            self.assertEquals(''.join(resp), '')
 
     def test_object_HEAD(self):
         self._test_object_GETorHEAD('HEAD')
@@ -531,7 +545,7 @@ class TestSwift3(unittest.TestCase):
                             headers={'Authorization': 'AWS test:tester:hmac',
                                      'x-amz-storage-class': 'REDUCED_REDUNDANCY',
                                      'Content-MD5': 'Gyz1NfJ3Mcl0NDZFo5hTKA=='})
-        req.date = datetime.now()
+        req.date = datetime.utcnow()
         req.content_type = 'text/plain'
         resp = local_app(req.environ, local_app.app.do_start_response)
         self.assertEquals(local_app.app.response_args[0].split()[0], '200')
@@ -545,7 +559,7 @@ class TestSwift3(unittest.TestCase):
         class FakeApp(object):
             def __call__(self, env, start_response):
                 self.req = Request(env)
-                start_response('200 OK', [])
+                start_response('201 OK', [])
                 return []
         app = FakeApp()
         local_app = swift3.filter_factory({})(app)
@@ -556,7 +570,7 @@ class TestSwift3(unittest.TestCase):
                                  'X-Amz-Meta-Something': 'oh hai',
                                  'X-Amz-Copy-Source': '/some/source',
                                  'Content-MD5': 'ffoHqOWd280dyE1MT4KuoQ=='})
-        req.date = datetime.now()
+        req.date = datetime.utcnow()
         req.content_type = 'text/plain'
         resp = local_app(req.environ, lambda *args: None)
         self.assertEquals(app.req.headers['ETag'],
@@ -677,13 +691,17 @@ class TestSwift3(unittest.TestCase):
                 return []
         app = FakeApp()
         local_app = swift3.filter_factory({})(app)
-        req = Request.blank('/bucket/object?Signature=X&Expires=Y&'
-                'AWSAccessKeyId=Z', environ={'REQUEST_METHOD': 'GET'})
-        req.headers['Date'] = datetime.utcnow()
+        dt = datetime.utcnow()
+        dt_formatted = dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+        req = Request.blank(
+            '/bucket/object?Signature=X&Expires=%s&AWSAccessKeyId=Z' % (
+                urllib.quote(dt_formatted)),
+            environ={'REQUEST_METHOD': 'GET'})
+        req.date = dt
         req.content_type = 'text/plain'
         resp = local_app(req.environ, lambda *args: None)
-        self.assertEquals(req.headers['Authorization'], 'AWS Z:X')
-        self.assertEquals(req.headers['Date'], 'Y')
+        self.assertEquals(app.req.headers['Authorization'], 'AWS Z:X')
+        self.assertEquals(app.req.headers['Date'], dt_formatted)
 
     def test_token_generation(self):
         req = Request.blank('/bucket/object?uploadId=123456789abcdef'

--- a/swift3/test/unit/test_swift3.py
+++ b/swift3/test/unit/test_swift3.py
@@ -458,9 +458,7 @@ class TestSwift3(unittest.TestCase):
         self.assertEquals(local_app.app.response_args[0].split()[0], '204')
 
     def _check_acl(self, owner, resp):
-        xml_string = ''.join(resp)
-        import sys; print >>sys.stderr, 'xml_string: %s' % xml_string
-        dom = xml.dom.minidom.parseString(xml_string)
+        dom = xml.dom.minidom.parseString(''.join(resp))
         self.assertEquals(dom.firstChild.nodeName, 'AccessControlPolicy')
         name = dom.getElementsByTagName('Permission')[0].childNodes[0].nodeValue
         self.assertEquals(name, 'FULL_CONTROL')


### PR DESCRIPTION
Fix swift3 behavior with set_acl to existing container

S3 allows a bucket PUT with an X-Aws-Acl header (e.g. canned acl) and an "acl" query param.  But swift3 was erroneously returning BucketAlreadyExists.  This patch fixes swift3 to allow this action which S3 allows.

Also some restructuring of how XML is constructed to be more (IMO) readable.
