### PR TITLE
Don't put as Z suffix at the end of dates.

### DIFF
--- a/swift3/middleware.py
+++ b/swift3/middleware.py
@@ -530,7 +530,7 @@ class BucketController(WSGIContext):
                 'false',
                 max_keys,
                 xml_escape(self.container_name),
-                "".join(['<Contents><Key>%s</Key><LastModified>%sZ</LastModif'
+                "".join(['<Contents><Key>%s</Key><LastModified>%s</LastModif'
                         'ied><ETag>%s</ETag><Size>%s</Size><StorageClass>STA'
                         'NDARD</StorageClass><Owner><ID>%s</ID><DisplayName>'
                         '%s</DisplayName></Owner></Contents>' %


### PR DESCRIPTION
ISO-8601 / http://www.w3.org/TR/NOTE-datetime mentions:

  This profile defines two ways of handling time zone offsets:
1. Times are expressed in UTC (Coordinated Universal Time), with a
    special UTC designator ("Z").
2. Times are expressed in local time, together with a time zone
    offset in hours and minutes. A time zone offset of "+hh:mm"
    indicates that the date/time uses a local time zone which is "hh"
    hours and "mm" minutes ahead of UTC. A time zone offset of
    "-hh:mm" indicates that the date/time uses a local time zone
    which is "hh" hours and "mm" minutes behind UTC.
   
   A standard referencing this profile should permit one or both of
   these ways of handling time zone offsets.  "

The 'Z' character will be part of the data string already if needed,
adding a second one causes various tools to behave badly.
